### PR TITLE
Make LdapPartialAttribute contain Vec<u8>

### DIFF
--- a/examples/tokio/main.rs
+++ b/examples/tokio/main.rs
@@ -37,11 +37,11 @@ impl LdapSession {
                 attributes: vec![
                     LdapPartialAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["cursed".to_string()],
+                        vals: vec![b"cursed".to_vec()],
                     },
                     LdapPartialAttribute {
                         atype: "cn".to_string(),
-                        vals: vec!["hello".to_string()],
+                        vals: vec![b"hello".to_vec()],
                     },
                 ],
             }),
@@ -50,11 +50,11 @@ impl LdapSession {
                 attributes: vec![
                     LdapPartialAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["cursed".to_string()],
+                        vals: vec![b"cursed".to_vec()],
                     },
                     LdapPartialAttribute {
                         atype: "cn".to_string(),
-                        vals: vec!["world".to_string()],
+                        vals: vec![b"world".to_vec()],
                     },
                 ],
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,15 +174,15 @@ mod tests {
                 attributes: vec![
                     LdapPartialAttribute {
                         atype: "cn".to_string(),
-                        vals: vec!["demo".to_string(),]
+                        vals: vec![b"demo".to_vec()]
                     },
                     LdapPartialAttribute {
                         atype: "dn".to_string(),
-                        vals: vec!["cn=demo,dc=example,dc=com".to_string(),]
+                        vals: vec![b"cn=demo,dc=example,dc=com".to_vec()]
                     },
                     LdapPartialAttribute {
                         atype: "objectClass".to_string(),
-                        vals: vec!["cursed".to_string(),]
+                        vals: vec![b"cursed".to_vec()]
                     },
                 ]
             }),
@@ -257,7 +257,7 @@ mod tests {
                 dn: "dc=example,dc=com".to_string(),
                 attributes: vec![LdapPartialAttribute {
                     atype: "objectClass".to_string(),
-                    vals: vec!["top".to_string(), "posixAccount".to_string()]
+                    vals: vec![b"top".to_vec(), b"posixAccount".to_vec()]
                 }],
             }),
             ctrl: vec![],
@@ -320,7 +320,7 @@ mod tests {
                     operation: LdapModifyType::Replace,
                     modification: LdapPartialAttribute {
                         atype: "userPassword".to_string(),
-                        vals: vec!["password".to_string()],
+                        vals: vec![b"password".to_vec()],
                     }
                 }],
             }),

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -178,7 +178,7 @@ pub struct LdapSearchRequest {
 #[derive(Clone, PartialEq)]
 pub struct LdapPartialAttribute {
     pub atype: String,
-    pub vals: Vec<String>,
+    pub vals: Vec<Vec<u8>>,
 }
 
 // A PartialAttribute allows zero values, while
@@ -1444,7 +1444,6 @@ impl TryFrom<StructureTag> for LdapPartialAttribute {
                         bv.match_class(TagClass::Universal)
                             .and_then(|t| t.match_id(Types::OctetString as u64))
                             .and_then(|t| t.expect_primitive())
-                            .and_then(|bv| String::from_utf8(bv).ok())
                     })
                     .collect();
                 r
@@ -1499,9 +1498,9 @@ impl From<LdapPartialAttribute> for Tag {
                 Tag::Set(Set {
                     inner: vals
                         .into_iter()
-                        .map(|v| {
+                        .map(|inner| {
                             Tag::OctetString(OctetString {
-                                inner: Vec::from(v),
+                                inner,
                                 ..Default::default()
                             })
                         })


### PR DESCRIPTION
I believe that's all that's needed for attributes. However, given that the LDAP specification has no mention of UTF-8, most other attributes should probably be switched to bytes as well. I guess we can keep the attribute names, DN and so on as `String` since they're gonna be ASCII anyway, but all the filters and so on would _technically_ require byte vectors as well. I'm not sure if you want to do that change.