### PR TITLE
A smoll collection of LDAP protocol conformance fixes

### DIFF
--- a/proto/examples/sasltest/main.rs
+++ b/proto/examples/sasltest/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[allow(clippy::expect_used, clippy::expect_fun_call)]
     let addr = SocketAddr::from_str(&ldap_server_addr).expect(&format!(
         "Unable to parse address, addr is {:?}",
-        &ldap_server_addr
+        ldap_server_addr
     ));
 
     let tcpstream = TcpStream::connect(addr).await?;

--- a/proto/examples/search/main.rs
+++ b/proto/examples/search/main.rs
@@ -20,7 +20,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ldap_server_addr = env::var("LDAP_SERVER_ADDR").expect("LDAP_SERVER_ADDR not set"); // domain.com:port
     let ldap_username_dn = env::var("LDAP_USERNAME_DN").expect("LDAP_USERNAME_DN not set"); // username@domain
     let addr = SocketAddr::from_str(&ldap_server_addr)
-        .unwrap_or_else(|_| panic!("Unable to parse address, addr is {:?}", &ldap_server_addr));
+        .unwrap_or_else(|_| panic!("Unable to parse address, addr is {:?}", ldap_server_addr));
 
     let tcpstream = TcpStream::connect(addr).await?;
 

--- a/proto/src/control.rs
+++ b/proto/src/control.rs
@@ -597,6 +597,10 @@ impl TryFrom<StructureTag> for LdapControl {
                     }
                 }
 
+                // RFC 2891 §1.1 requires at least one sort key.
+                if requests.is_empty() {
+                    return Err(LdapProtoError::ControlBer);
+                }
                 requests.reverse();
                 Ok(LdapControl::ServerSort {
                     sort_requests: requests,

--- a/proto/src/control.rs
+++ b/proto/src/control.rs
@@ -974,11 +974,15 @@ impl From<LdapControl> for Tag {
                                 id: 0,
                             }));
                         }
-                        inner.push(Tag::Boolean(Boolean {
-                            inner: sort_request.reverse_order,
-                            class: TagClass::Context,
-                            id: 1,
-                        }));
+                        // DEFAULT FALSE is absent on the wire (RFC 4511 §5.1).
+                        if sort_request.reverse_order {
+                            let reverse = Tag::Boolean(Boolean {
+                                inner: true,
+                                class: TagClass::Context,
+                                id: 1,
+                            });
+                            inner.push(reverse);
+                        }
                         Tag::Sequence(Sequence {
                             inner,
                             ..Default::default()

--- a/proto/src/control.rs
+++ b/proto/src/control.rs
@@ -534,6 +534,74 @@ impl TryFrom<StructureTag> for LdapControl {
 
                 Ok(LdapControl::ManageDsaIT { criticality })
             }
+            // RFC 2891 §1.1.1: Server-Side Sort request control.
+            // Wire: SEQUENCE OF SEQUENCE { attributeType OCTET STRING,
+            //   [0] orderingRule OCTET STRING OPTIONAL,
+            //   [1] reverseOrder BOOLEAN }
+            "1.2.840.113556.1.4.473" => {
+                let value = value_tag
+                    .and_then(|t| t.match_class(TagClass::Universal))
+                    .and_then(|t| t.match_id(Types::OctetString as u64))
+                    .and_then(|t| t.expect_primitive())
+                    .ok_or(LdapProtoError::ControlBer)?;
+
+                let mut parser = Parser::default();
+                let (_, tag) = parser
+                    .parse(&value)
+                    .map_err(|_| LdapProtoError::ControlBer)?;
+
+                let mut sort_keys = tag
+                    .match_class(TagClass::Universal)
+                    .and_then(|t| t.match_id(Types::Sequence as u64))
+                    .and_then(|t| t.expect_constructed())
+                    .ok_or(LdapProtoError::ControlBer)?;
+
+                let mut requests = Vec::with_capacity(sort_keys.len());
+                while let Some(key_tag) = sort_keys.pop() {
+                    let mut inner = key_tag
+                        .match_class(TagClass::Universal)
+                        .and_then(|t| t.match_id(Types::Sequence as u64))
+                        .and_then(|t| t.expect_constructed())
+                        .ok_or(LdapProtoError::ControlBer)?;
+
+                    // Inner tags are pushed in order attr, [0] rule, [1] bool;
+                    // pop() yields them reverse: bool?, rule?, attr.
+                    let mut reverse_order = false;
+                    let mut ordering_rule = None;
+                    while let Some(t) = inner.pop() {
+                        // [1] reverseOrder — Context class, id 1, Boolean.
+                        if t.class == TagClass::Context && t.id == 1 {
+                            reverse_order = t
+                                .expect_primitive()
+                                .and_then(|bytes| bytes.first().copied())
+                                .map(|b| b != 0)
+                                .unwrap_or(false);
+                        // [0] orderingRule — Context class, id 0, OctetString.
+                        } else if t.class == TagClass::Context && t.id == 0 {
+                            ordering_rule =
+                                t.expect_primitive().map(|bytes| bytes_to_string!(bytes));
+                        // attributeType is the one mandatory field.
+                        } else if t.class == TagClass::Universal
+                            && t.id == Types::OctetString as u64
+                        {
+                            let bytes = t.expect_primitive().ok_or(LdapProtoError::ControlBer)?;
+                            requests.push(ServerSortRequet {
+                                attribute_name: bytes_to_string!(bytes),
+                                ordering_rule: ordering_rule.take(),
+                                reverse_order,
+                            });
+                            reverse_order = false;
+                        } else {
+                            return Err(LdapProtoError::ControlBer);
+                        }
+                    }
+                }
+
+                requests.reverse();
+                Ok(LdapControl::ServerSort {
+                    sort_requests: requests,
+                })
+            }
             "1.2.840.113556.1.4.474" => {
                 let value = value_tag
                     .and_then(|t| t.match_class(TagClass::Universal))

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -185,6 +185,34 @@ mod tests {
     }
 
     #[test]
+    fn test_ldapserver_codec_bindresponse_saslcreds() {
+        let msg = LdapMsg {
+            msgid: 999999,
+            op: LdapOp::BindResponse(LdapBindResponse {
+                res: LdapResult {
+                    code: LdapResultCode::Success,
+                    matcheddn: "cn=Directory Manager".to_string(),
+                    message: "It works!".to_string(),
+                    referral: vec![],
+                },
+                saslcreds: Some(vec![0x01, 0x02, 0x03]),
+            }),
+            ctrl: vec![],
+        };
+
+        let mut buf = BytesMut::new();
+        let mut server_codec = LdapCodec::default();
+        assert!(server_codec.encode(msg.clone(), &mut buf).is_ok());
+        // serverSaslCreds is [7] IMPLICIT OCTET STRING (0x87) per RFC 4511 §4.2.2.
+        assert!(
+            buf.windows(5).any(|w| w == [0x87, 0x03, 0x01, 0x02, 0x03]),
+            "saslcreds missing from encoded bind response: {buf:02x?}"
+        );
+        let res = server_codec.decode(&mut buf).expect("failed to decode");
+        assert_eq!(res.expect("None found?"), msg);
+    }
+
+    #[test]
     fn test_ldapserver_codec_searchrequest() {
         do_test!(LdapMsg {
             msgid: 2_147_483_646,

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -255,6 +255,39 @@ mod tests {
     }
 
     #[test]
+    fn test_ldapserver_sort_control_default_reverse_omitted() {
+        let msg = LdapMsg {
+            msgid: 1,
+            op: LdapOp::SearchRequest(LdapSearchRequest {
+                base: "dc=example,dc=com".to_string(),
+                scope: LdapSearchScope::Subtree,
+                aliases: LdapDerefAliases::Never,
+                sizelimit: 0,
+                timelimit: 0,
+                typesonly: false,
+                filter: LdapFilter::Present("objectClass".to_string()),
+                attrs: vec![],
+            }),
+            ctrl: vec![LdapControl::ServerSort {
+                sort_requests: vec![ServerSortRequet {
+                    attribute_name: "cn".to_string(),
+                    ordering_rule: None,
+                    reverse_order: false,
+                }],
+            }],
+        };
+
+        let mut buf = BytesMut::new();
+        let mut server_codec = LdapCodec::default();
+        assert!(server_codec.encode(msg, &mut buf).is_ok());
+        // reverseOrder DEFAULT FALSE is absent (RFC 4511 §5.1); [1] is 0x81.
+        assert!(
+            !buf.windows(2).any(|w| w == [0x81, 0x01]),
+            "default reverseOrder emitted: {buf:02x?}"
+        );
+    }
+
+    #[test]
     fn test_ldapserver_codec_searchrequest() {
         do_test!(LdapMsg {
             msgid: 2_147_483_646,

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -118,7 +118,7 @@ impl Encoder<LdapMsg> for LdapCodec {
 #[cfg(test)]
 mod tests {
     use crate::LdapCodec;
-    use crate::control::LdapControl;
+    use crate::control::{LdapControl, ServerSortRequet};
     use crate::error::LdapProtoError;
     use crate::parse_ldap_filter_str;
     use crate::proto::*;
@@ -220,6 +220,37 @@ mod tests {
                 uris: vec!["ldap://ldap.example.com/dc=example,dc=com".to_string()],
             }),
             ctrl: vec![],
+        });
+    }
+
+    #[test]
+    fn test_ldapserver_search_with_server_sort_control() {
+        do_test!(LdapMsg {
+            msgid: 1,
+            op: LdapOp::SearchRequest(LdapSearchRequest {
+                base: "dc=example,dc=com".to_string(),
+                scope: LdapSearchScope::Subtree,
+                aliases: LdapDerefAliases::Never,
+                sizelimit: 0,
+                timelimit: 0,
+                typesonly: false,
+                filter: LdapFilter::Present("objectClass".to_string()),
+                attrs: vec![],
+            }),
+            ctrl: vec![LdapControl::ServerSort {
+                sort_requests: vec![
+                    ServerSortRequet {
+                        attribute_name: "cn".to_string(),
+                        ordering_rule: None,
+                        reverse_order: false,
+                    },
+                    ServerSortRequet {
+                        attribute_name: "sn".to_string(),
+                        ordering_rule: Some("caseIgnoreOrderingMatch".to_string()),
+                        reverse_order: true,
+                    },
+                ],
+            }],
         });
     }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -213,6 +213,17 @@ mod tests {
     }
 
     #[test]
+    fn test_ldapserver_codec_searchresultreference() {
+        do_test!(LdapMsg {
+            msgid: 1,
+            op: LdapOp::SearchResultReference(LdapSearchResultReference {
+                uris: vec!["ldap://ldap.example.com/dc=example,dc=com".to_string()],
+            }),
+            ctrl: vec![],
+        });
+    }
+
+    #[test]
     fn test_ldapserver_codec_searchrequest() {
         do_test!(LdapMsg {
             msgid: 2_147_483_646,

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -3294,3 +3294,68 @@ impl TryFrom<Vec<StructureTag>> for LdapSearchResultReference {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ldap3_lber::structure::{PL, StructureTag};
+
+    fn int_tag(value: i64) -> StructureTag {
+        // Minimal two's-complement BER INTEGER, e.g. 3 -> [0x03].
+        let bytes = if (-128..=127).contains(&value) {
+            vec![value as u8]
+        } else {
+            let mut v = value;
+            let mut out = Vec::new();
+            while v != 0 && v != -1 {
+                out.push((v & 0xff) as u8);
+                v >>= 8;
+            }
+            out.push((v & 0xff) as u8);
+            out.reverse();
+            out
+        };
+        StructureTag {
+            class: TagClass::Universal,
+            id: Types::Integer as u64,
+            payload: PL::P(bytes),
+        }
+    }
+
+    fn octetstring_tag(s: &str) -> StructureTag {
+        StructureTag {
+            class: TagClass::Universal,
+            id: Types::OctetString as u64,
+            payload: PL::P(s.as_bytes().to_vec()),
+        }
+    }
+
+    fn simple_cred(password: &str) -> StructureTag {
+        // [0] (PRIMITIVE) OCTET STRING — simple authentication.
+        StructureTag {
+            class: TagClass::Context,
+            id: 0,
+            payload: PL::P(password.as_bytes().to_vec()),
+        }
+    }
+
+    /// RFC 4511 §4.2: a BindRequest whose version is not 3 must be rejected
+    /// at parse time.
+    #[test]
+    fn bind_request_version_2_rejected() {
+        // Children in sequence order: version, name, authentication.
+        let children = vec![int_tag(2), octetstring_tag("cn=test"), simple_cred("pw")];
+        let result = LdapBindRequest::try_from(children);
+        assert!(
+            matches!(result, Err(LdapProtoError::BindRequestVersion)),
+            "version 2 must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn bind_request_version_3_accepted() {
+        let children = vec![int_tag(3), octetstring_tag("cn=test"), simple_cred("pw")];
+        let result = LdapBindRequest::try_from(children);
+        assert!(result.is_ok(), "version 3 must parse: {result:?}");
+    }
+
+}

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -1533,9 +1533,16 @@ impl From<LdapBindResponse> for Vec<Tag> {
         res.into_tag_iter()
             .chain(once_with(|| {
                 saslcreds.map(|sc| {
+                    // Per RFC 4511 §4.2.2, serverSaslCreds is
+                    // [7] IMPLICIT OCTET STRING (context-specific,
+                    // primitive, tag 7 → wire byte 0x87). Emitting a
+                    // universal OCTET STRING (tag 0x04) is a protocol
+                    // error: Samba's ldb client, Windows, and openldap
+                    // all reject it with LDAP_PROTOCOL_ERROR.
                     Tag::OctetString(OctetString {
+                        id: 7,
+                        class: TagClass::Context,
                         inner: sc,
-                        ..Default::default()
                     })
                 })
             }))
@@ -3286,3 +3293,4 @@ impl TryFrom<Vec<StructureTag>> for LdapSearchResultReference {
         Ok(LdapSearchResultReference { uris })
     }
 }
+

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -3278,6 +3278,10 @@ impl TryFrom<Vec<StructureTag>> for LdapSearchResultReference {
     type Error = LdapProtoError;
 
     fn try_from(value: Vec<StructureTag>) -> Result<Self, Self::Error> {
+        // SIZE (1..MAX) per RFC 4511 §4.5.3.
+        if value.is_empty() {
+            return Err(LdapProtoError::LdapMsgBer);
+        }
         let mut uris = Vec::new();
 
         // Iterate over the StructureTags
@@ -3515,4 +3519,20 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn sort_control_empty_key_list_rejected() {
+        let control = sort_control_tag(vec![]);
+        assert!(matches!(
+            LdapControl::try_from(control),
+            Err(LdapProtoError::ControlBer)
+        ));
+    }
+
+    #[test]
+    fn search_result_reference_empty_rejected() {
+        assert!(matches!(
+            LdapSearchResultReference::try_from(vec![]),
+            Err(LdapProtoError::LdapMsgBer)
+        ));
+    }
 }

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -3358,4 +3358,161 @@ mod tests {
         assert!(result.is_ok(), "version 3 must parse: {result:?}");
     }
 
+    // RFC 2891 §1.1: SortKeyList is SEQUENCE OF SEQUENCE {
+    //   attributeType, [0] orderingRule OPTIONAL, [1] reverseOrder BOOLEAN }.
+    fn sort_key_tag(
+        attribute_name: &str,
+        ordering_rule: Option<&str>,
+        reverse_order: Option<bool>,
+    ) -> StructureTag {
+        let mut inner = vec![octetstring_tag(attribute_name)];
+        if let Some(rule) = ordering_rule {
+            inner.push(StructureTag {
+                class: TagClass::Context,
+                id: 0,
+                payload: PL::P(rule.as_bytes().to_vec()),
+            });
+        }
+        if let Some(reverse) = reverse_order {
+            inner.push(StructureTag {
+                class: TagClass::Context,
+                id: 1,
+                payload: PL::P(vec![if reverse { 0xff } else { 0x00 }]),
+            });
+        }
+        StructureTag {
+            class: TagClass::Universal,
+            id: Types::Sequence as u64,
+            payload: PL::C(inner),
+        }
+    }
+
+    fn sort_control_tag(keys: Vec<StructureTag>) -> StructureTag {
+        // controlValue holds the BER of SortKeyList inside an OCTET STRING.
+        let mut value_bytes = BytesMut::new();
+        lber_write::encode_into(
+            &mut value_bytes,
+            StructureTag {
+                class: TagClass::Universal,
+                id: Types::Sequence as u64,
+                payload: PL::C(keys),
+            },
+        )
+        .expect("encode SortKeyList");
+        StructureTag {
+            class: TagClass::Universal,
+            id: Types::Sequence as u64,
+            payload: PL::C(vec![
+                octetstring_tag("1.2.840.113556.1.4.473"),
+                StructureTag {
+                    class: TagClass::Universal,
+                    id: Types::OctetString as u64,
+                    payload: PL::P(value_bytes.to_vec()),
+                },
+            ]),
+        }
+    }
+
+    fn sort_request(
+        attribute_name: &str,
+        ordering_rule: Option<&str>,
+        reverse_order: bool,
+    ) -> crate::control::ServerSortRequet {
+        crate::control::ServerSortRequet {
+            attribute_name: attribute_name.to_string(),
+            ordering_rule: ordering_rule.map(str::to_string),
+            reverse_order,
+        }
+    }
+
+    #[test]
+    fn sort_control_single_key_parsed() {
+        let control = sort_control_tag(vec![sort_key_tag("cn", None, None)]);
+        let parsed = LdapControl::try_from(control).expect("parse sort control");
+        assert_eq!(
+            parsed,
+            LdapControl::ServerSort {
+                sort_requests: vec![sort_request("cn", None, false)],
+            }
+        );
+    }
+
+    #[test]
+    fn sort_control_multi_key_order_preserved() {
+        // Keys are highest-precedence first; a reversed vec would flip them.
+        let control = sort_control_tag(vec![
+            sort_key_tag("cn", None, None),
+            sort_key_tag("sn", None, None),
+        ]);
+        let parsed = LdapControl::try_from(control).expect("parse sort control");
+        assert_eq!(
+            parsed,
+            LdapControl::ServerSort {
+                sort_requests: vec![
+                    sort_request("cn", None, false),
+                    sort_request("sn", None, false),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn sort_control_ordering_rule_parsed() {
+        let control = sort_control_tag(vec![sort_key_tag(
+            "cn",
+            Some("caseIgnoreOrderingMatch"),
+            None,
+        )]);
+        let parsed = LdapControl::try_from(control).expect("parse sort control");
+        assert_eq!(
+            parsed,
+            LdapControl::ServerSort {
+                sort_requests: vec![sort_request("cn", Some("caseIgnoreOrderingMatch"), false)],
+            }
+        );
+    }
+
+    #[test]
+    fn sort_control_reverse_order_parsed() {
+        let control = sort_control_tag(vec![sort_key_tag("cn", None, Some(true))]);
+        let parsed = LdapControl::try_from(control).expect("parse sort control");
+        assert_eq!(
+            parsed,
+            LdapControl::ServerSort {
+                sort_requests: vec![sort_request("cn", None, true)],
+            }
+        );
+    }
+
+    #[test]
+    fn sort_control_full_key_parsed() {
+        let control = sort_control_tag(vec![sort_key_tag(
+            "cn",
+            Some("caseIgnoreOrderingMatch"),
+            Some(true),
+        )]);
+        let parsed = LdapControl::try_from(control).expect("parse sort control");
+        assert_eq!(
+            parsed,
+            LdapControl::ServerSort {
+                sort_requests: vec![sort_request("cn", Some("caseIgnoreOrderingMatch"), true)],
+            }
+        );
+    }
+
+    #[test]
+    fn sort_control_foreign_attribute_rejected() {
+        // attributeType must be an OCTET STRING.
+        let key = StructureTag {
+            class: TagClass::Universal,
+            id: Types::Integer as u64,
+            payload: PL::P(vec![1]),
+        };
+        let control = sort_control_tag(vec![key]);
+        assert!(matches!(
+            LdapControl::try_from(control),
+            Err(LdapProtoError::ControlBer)
+        ));
+    }
+
 }

--- a/proto/src/simple.rs
+++ b/proto/src/simple.rs
@@ -1,7 +1,7 @@
 use crate::proto::*;
 pub use crate::proto::{
     LdapFilter, LdapMsg, LdapPartialAttribute, LdapResultCode, LdapSearchResultEntry,
-    LdapSearchScope,
+    LdapSearchResultReference, LdapSearchScope,
 };
 use std::convert::TryFrom;
 
@@ -131,6 +131,16 @@ impl SearchRequest {
         LdapMsg {
             msgid: self.msgid,
             op: LdapOp::SearchResultEntry(entry),
+            ctrl: vec![],
+        }
+    }
+
+    /// Build a [`LdapOp::SearchResultReference`] message (RFC 4511 §4.5.3)
+    /// for a continuation reference returned during a search.
+    pub fn gen_result_reference(&self, reference: LdapSearchResultReference) -> LdapMsg {
+        LdapMsg {
+            msgid: self.msgid,
+            op: LdapOp::SearchResultReference(reference),
             ctrl: vec![],
         }
     }


### PR DESCRIPTION
## Protocol fixes

Thank you so much for providing this crate. It has been insanely helpful in my own work, and so I would like to contribute back a few fixes I have been running in my own fork for a while.

I do hope my understanding of the RFCs is correct here.

### serverSaslCreds wire tag (RFC 4511 §4.2.2)

`serverSaslCreds` is now encoded as [7] IMPLICIT OCTET STRING (0x87) instead of a universal OCTET STRING (0x04). The previous encoding was rejected with `LDAP_PROTOCOL_ERROR` e.g. by Samba's `ldb` client, Windows, and `OpenLDAP`. The encode side now matches the existing parse side.

### Server-Side Sort request control (RFC 2891 §1.1)

- Parses the `1.2.840.113556.1.4.473` request control: `SortKeyList` with `attributeType`, optional [0] orderingRule, optional [1] reverseOrder.
- Preserves sort-key precedence order (previously reversed by the parser's stack-pop).
- Rejects malformed keys: `attributeType` must be an OCTET STRING; unknown tags are a `ControlBer` error.
- `reverseOrder` is no longer emitted when `FALSE` — RFC 4511 §5.1 requires default values to be absent.
- Enforces a non-empty key list.

### SearchResultReference builder (RFC 4511 §4.5.3)

New `SearchRequest::gen_result_reference` helper so servers can emit continuation references, plus a `LdapSearchResultReference` re-export.

### SIZE (1..MAX) enforcement

Empty `SearchResultReference` URI lists and empty sort key lists are rejected at parse time.

### Bind version enforcement tests (RFC 4511 §4.2)

Tests for the existing version-3-only parse check (version 2 rejected, version 3 accepted).

## Testing

I added some regression tests this time:

- raw-wire assertions (saslCreds 0x87 byte, absence of the default reverseOrder tag),
- direct BER-parse tests for every legal SortKeyList shape plus malformed inputs,
- codec round-trips (sort control, search result reference, SASL bind response).
